### PR TITLE
Improve pack submission form and adjust CI to generate artifacts on main

### DIFF
--- a/.github/ISSUE_TEMPLATE/pack_submission.yml
+++ b/.github/ISSUE_TEMPLATE/pack_submission.yml
@@ -4,24 +4,89 @@ title: "Pack submission: <slug>"
 labels: ["pack"]
 body:
   - type: input
-    id: slug
-    attributes:
-      label: Pack slug (kebab-case)
-      placeholder: "example-pack"
-    validations:
-      required: true
-  - type: input
     id: title
     attributes:
       label: Pack title
+      placeholder: "Your pack title"
+    validations:
+      required: true
+  - type: input
+    id: slug
+    attributes:
+      label: Suggested slug (kebab-case)
+      description: "Derive from the title: lowercase, numbers ok, dash-separated, no spaces/underscores, 3–48 chars. Examples: barthopoulos-ji-basics, example-12tet, partch-43."
+      placeholder: "example-12tet"
     validations:
       required: true
   - type: input
     id: author
     attributes:
-      label: Author credit
+      label: Author name
+      placeholder: "Jane Doe"
     validations:
       required: true
+  - type: input
+    id: author_url
+    attributes:
+      label: Author URL (optional)
+      placeholder: "https://example.com"
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Description (1–3 sentences)
+      placeholder: "A short description of the tuning and its use."
+    validations:
+      required: true
+  - type: input
+    id: tags
+    attributes:
+      label: Tags (comma-separated)
+      placeholder: "ji, microtonal, tutorial"
+    validations:
+      required: true
+  - type: input
+    id: root_hz
+    attributes:
+      label: defaults.rootHz
+      description: "Root frequency in Hz."
+      placeholder: "440"
+    validations:
+      required: true
+  - type: dropdown
+    id: prime_limit
+    attributes:
+      label: defaults.primeLimit
+      description: "Prime limit for the pack."
+      options:
+        - "5"
+        - "7"
+        - "11"
+        - "13"
+        - "17"
+        - "19"
+        - "23"
+        - "31"
+      default: "13"
+    validations:
+      required: true
+  - type: input
+    id: scala_files
+    attributes:
+      label: Scala filename(s) you’ll upload
+      description: "One or more .scl/.ascl/.scala filenames."
+      placeholder: "my-scale.scl"
+    validations:
+      required: true
+  - type: input
+    id: kbm_file
+    attributes:
+      label: Optional KBM filename
+      description: "If you have one, the .kbm filename."
+      placeholder: "my-scale.kbm"
+    validations:
+      required: false
   - type: checkboxes
     id: license
     attributes:
@@ -29,16 +94,43 @@ body:
       options:
         - label: "I confirm this pack is licensed under CC0-1.0"
           required: true
-  - type: textarea
-    id: files
+  - type: markdown
     attributes:
-      label: Source files
-      description: List the Scala/KBM files you will upload (paths under packs/<slug>/sources).
-      placeholder: "sources/scale.scl, sources/scale.kbm"
-    validations:
-      required: true
-  - type: textarea
-    id: notes
-    attributes:
-      label: Notes
-      description: Any extra details about the tuning or provenance.
+      value: |
+        ## Next steps (copy/paste + upload)
+
+        **Upload files:**
+        https://github.com/stagedevices/tenney-scales/upload/main
+
+        **Open PR:**
+        https://github.com/stagedevices/tenney-scales/compare
+
+        **Create these paths:**
+        - `packs/<slug>/pack.json`
+        - `packs/<slug>/sources/<yourfile>.scl` (or `.ascl` / `.scala`)
+        - `packs/<slug>/sources/<optional>.kbm`
+
+        **Fast path (2 clicks):**
+        1. Create `packs/<slug>/pack.json` (Add file → Create new file)
+        2. Upload `.scl/.ascl` (+ optional `.kbm`) into `packs/<slug>/sources/` (Add file → Upload files)
+        3. Click the banner “Create pull request” or open `…/compare`
+
+        **Paste-ready `pack.json` template** (set both timestamps to *today* in this exact format; **no milliseconds**):
+
+        ```json
+        {
+          "slug": "<slug>",
+          "title": "<title>",
+          "description": "<description>",
+          "author": "<author>",
+          "authorUrl": "https://example.com",
+          "license": "CC0-1.0",
+          "tags": ["<tag1>", "<tag2>"],
+          "createdAt": "2026-01-01T00:00:00Z",
+          "updatedAt": "2026-01-01T00:00:00Z",
+          "defaults": { "rootHz": 440, "primeLimit": 13 },
+          "inputs": { "scala": "sources/<file>.scl", "kbm": "sources/<file>.kbm" }
+        }
+        ```
+
+        If you don’t have an author URL, remove the `authorUrl` line entirely (empty strings won’t validate).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
-  normalize:
-    runs-on: ubuntu-latest
+  pr-checks:
+    if: github.event_name == 'pull_request'
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -18,15 +22,49 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Normalize and validate
-        run: npm run check
-
-  contract:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Validate pack schemas
+        run: npm run validate
+      - name: Normalize packs
+        run: npm run normalize
+      - name: Generate index
+        run: npm run index
       - name: Swift version
         run: swift --version
       - name: Run contract validator
         run: swift run --package-path tools/contract TenneyContractValidator
+
+  main-normalize:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]'
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Normalize packs
+        run: npm run normalize
+      - name: Generate index
+        run: npm run index
+      - name: Swift version
+        run: swift --version
+      - name: Run contract validator
+        run: swift run --package-path tools/contract TenneyContractValidator
+      - name: Commit generated outputs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add packs/**/tenney INDEX.json
+            git commit -m "chore: normalize packs [skip ci]"
+            git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+            git push origin HEAD:main
+          else
+            echo "No generated changes to commit."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 You can upload a pack directly using the GitHub web UI—no local tooling required.
 
+Use the pack submission issue form:
+https://github.com/stagedevices/tenney-scales/issues/new?template=pack_submission.yml
+
 ## 1) Create your folder
 
 Create a new folder under `packs/` with a slug in lowercase kebab-case, for example:
@@ -15,11 +18,9 @@ Inside that folder, create:
 ```
 pack.json
 sources/
-tenney/
-previews/
 ```
 
-`tenney/` and `previews/` can be empty on first upload.
+Only `pack.json` and `sources/*` are needed from contributors. `tenney/` outputs and `INDEX.json` are generated automatically after merge.
 
 ## 2) Fill out `pack.json`
 
@@ -28,14 +29,14 @@ previews/
 * `slug` (must match the folder name)
 * `title`, `description`, `author`
 * `license` **must be** `CC0-1.0`
-* `createdAt` and `updatedAt` in ISO8601 format (e.g. `2026-01-01T00:00:00Z`)
+* `createdAt` and `updatedAt` in strict ISO8601 format (e.g. `2026-01-01T00:00:00Z`)
 * `defaults.rootHz` (usually 440) and `defaults.primeLimit`
 * `inputs.scala` (relative path under `sources/`)
 * `inputs.kbm` (optional; also under `sources/`)
 
 ## 3) Add your source files
 
-Upload your `.scl` (and optional `.kbm`) into `sources/`. Keep files under 2 MB.
+Upload your `.scl`/`.ascl`/`.scala` (and optional `.kbm`) into `sources/`. Keep files under 2 MB.
 
 ## 4) (Optional) Run checks locally
 
@@ -43,10 +44,12 @@ If you want to validate locally:
 
 ```bash
 npm install
-npm run check
+npm run validate
+npm run normalize
+npm run index
+swift run --package-path tools/contract TenneyContractValidator
 ```
 
 ## 5) Open a pull request
 
-CI runs the same validation, normalization, index generation, and a Swift contract decoder.
-If CI fails, it will tell you which pack needs attention.
+CI runs schema validation, normalization, index generation, and a Swift contract decoder. It does **not** require generated outputs to be committed in PRs.


### PR DESCRIPTION
### Motivation
- Make contributing a pack as close to “copy/paste + upload” as possible by providing slug guidance, a paste-ready `pack.json` template with strict ISO8601 timestamps, and explicit upload/PR links and paths. 
- Prevent contributors from having to commit generated artifacts by running normalization/indexing in CI for PR validation while only committing generated outputs from `main`.

### Description
- Update `.github/ISSUE_TEMPLATE/pack_submission.yml` to a 2-step wizard that collects `title`, `slug` (with guidance and examples), `author`, optional `authorUrl`, `description`, `tags`, `defaults.rootHz`, `defaults.primeLimit` (dropdown), scala/KBM filenames, and a CC0 license checkbox, and adds a markdown “Next steps” block with the two big links, exact folder paths, a two-click fast path checklist, and a paste-ready `pack.json` template that uses strict `YYYY-MM-DDTHH:MM:SSZ` timestamps and warns “no milliseconds”.
- Replace/adjust `.github/workflows/ci.yml` to separate PR and main workflows: the PR job (`pr-checks`) runs `npm run validate`, `npm run normalize`, `npm run index`, and the Swift contract validator (`swift run --package-path tools/contract TenneyContractValidator`) against locally generated outputs and explicitly removes any git-diff enforcement so PRs do not need committed generated artifacts.
- Add `main-normalize` job that only runs on pushes to `main` when `github.actor != 'github-actions[bot]'`, runs the same normalize/index/validator steps, and commits generated outputs back to `main` using `GITHUB_TOKEN` with git user `github-actions[bot]` and commit message `chore: normalize packs [skip ci]` to avoid loops; the job stages include `git add packs/**/tenney INDEX.json` before commit.
- Update `CONTRIBUTING.md` to point to the updated issue form, emphasize contributors only add `pack.json` + `sources/*`, and note that `tenney/` outputs and `INDEX.json` are generated automatically after merge; local check instructions updated to run `npm run validate`, `npm run normalize`, `npm run index`, and the Swift validator.

### Testing
- No automated tests were executed locally as part of this patch; changes were committed and the workflow configuration was updated.
- The PR workflow is configured to run `npm run validate`, `npm run normalize`, `npm run index`, and `swift run --package-path tools/contract TenneyContractValidator` as automated checks for `pull_request` events (these will run when a PR is opened).
- The `push`->`main` workflow is configured to run the same automated steps and will commit generated outputs back to `main` using `GITHUB_TOKEN` when diffs exist; this commit uses `[skip ci]` and the actor guard to prevent infinite loops.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b0157f3048327b872c7f4a08c0a91)