### PR TITLE
chore: ignore Swift build artifacts in CI gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add packs/**/tenney INDEX.json
-            git commit -m "chore: normalize packs [skip ci]"
-            git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-            git push origin HEAD:main
-          else
+          if git diff --quiet; then
             echo "No generated changes to commit."
+            exit 0
           fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packs/**/tenney INDEX.json
+
+          if git diff --cached --quiet; then
+            echo "No staged changes to commit."
+            exit 0
+          fi
+
+          git commit -m "chore: normalize packs [skip ci]"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin HEAD:main

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 tools/tenney-normalize/dist/
+tools/contract/.build/
+tools/contract/.swiftpm/
+.DS_Store


### PR DESCRIPTION
### Motivation

- CI was failing because untracked Swift build outputs in `tools/contract/.build/` caused the commit step to detect changes and exit non-zero. 
- The main branch normalize workflow should only commit tracked changes (normalized `packs/**/tenney` and `INDEX.json`) and must not add or commit Swift build artifacts.

### Description

- Added `tools/contract/.build/`, `tools/contract/.swiftpm/`, and `.DS_Store` to `.gitignore` to stop untracked Swift build artifacts and macOS metadata from affecting CI. 
- Reworked the `Commit generated outputs` step in `.github/workflows/ci.yml` to check tracked diffs with `git diff --quiet` and to only commit when there are staged changes via `git diff --cached --quiet`. 
- Kept the existing `github.actor != 'github-actions[bot]'` guard and commit message `chore: normalize packs [skip ci]` behavior intact.

### Testing

- No automated tests were run locally; the repository CI (`pr-checks` and `main-normalize` workflows) will exercise `npm run normalize`, `npm run index`, and the Swift contract validator to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b0386774883278ab62d28ed5bb0fe)