### PR TITLE
Improve scaffold issue parsing robustness

### DIFF
--- a/tools/scaffold/scaffold-from-issue.test.mjs
+++ b/tools/scaffold/scaffold-from-issue.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const scriptPath = path.resolve("tools/scaffold/scaffold-from-issue.mjs");
+
+function buildIssueBody(overrides = {}) {
+  const fields = {
+    title: "My Test Pack",
+    preferredSlug: "_No response_",
+    author: "Test Author",
+    authorUrl: "_No response_",
+    description: "A short description.",
+    tags: "tag-one, tag-two",
+    rootHz: "440",
+    primeLimit: "11",
+    scaleFiles: "test",
+    globalKbm: "_No response_",
+    license: "- [x] I agree"
+  };
+  const values = { ...fields, ...overrides };
+  return [
+    `### Pack title`,
+    values.title,
+    "",
+    "### Preferred slug (optional)",
+    values.preferredSlug,
+    "",
+    "### Author display name",
+    values.author,
+    "",
+    "### Author URL (optional)",
+    values.authorUrl,
+    "",
+    "### Short description",
+    values.description,
+    "",
+    "### Tags (comma-separated)",
+    values.tags,
+    "",
+    "### defaults.rootHz",
+    values.rootHz,
+    "",
+    "### defaults.primeLimit",
+    values.primeLimit,
+    "",
+    "### Scale files list",
+    values.scaleFiles,
+    "",
+    "### Optional KBM filename",
+    values.globalKbm,
+    "",
+    "### License confirmation",
+    values.license,
+    ""
+  ].join("\n");
+}
+
+function runScaffold(issueBody) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "scaffold-"));
+  const issuePath = path.join(tempDir, "issue.md");
+  const outputPath = path.join(tempDir, "output.json");
+  fs.writeFileSync(issuePath, issueBody, "utf8");
+  const result = spawnSync(process.execPath, [scriptPath, issuePath, "--output", outputPath], {
+    cwd: tempDir,
+    encoding: "utf8"
+  });
+  return { result, tempDir, outputPath };
+}
+
+function readPackJson(tempDir, slug) {
+  const packPath = path.join(tempDir, "packs", slug, "pack.json");
+  return JSON.parse(fs.readFileSync(packPath, "utf8"));
+}
+
+test("blank preferred slug falls back to title", () => {
+  const { result, outputPath, tempDir } = runScaffold(buildIssueBody());
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  assert.equal(output.slug, "my-test-pack");
+  const pack = readPackJson(tempDir, output.slug);
+  assert.equal(pack.slug, "my-test-pack");
+});
+
+test("scala filename without extension defaults to .scl", () => {
+  const { result, outputPath, tempDir } = runScaffold(buildIssueBody({ scaleFiles: "test" }));
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  const pack = readPackJson(tempDir, output.slug);
+  assert.equal(pack.inputs.scales[0].scala, "sources/test.scl");
+});
+
+test("kbm filename without extension defaults to .kbm", () => {
+  const { result, outputPath, tempDir } = runScaffold(buildIssueBody({ scaleFiles: "foo.ascl | bar" }));
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  const pack = readPackJson(tempDir, output.slug);
+  assert.equal(pack.inputs.scales[0].kbm, "sources/bar.kbm");
+});
+
+test("invalid scala extension throws with helpful message", () => {
+  const { result } = runScaffold(buildIssueBody({ scaleFiles: "bad.txt" }));
+  assert.notEqual(result.status, 0);
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /\.scl, \.ascl, or \.scala/);
+});


### PR DESCRIPTION
### Motivation

- Make the Issue→Scaffold flow resilient to small user mistakes like missing optional slug, variant heading labels, and omitted file extensions.
- Normalize scala/KBM filenames and tighten filename validation to avoid creating invalid source paths.

### Description

- Accept multiple heading label variants via new helpers `requiredFieldAny(sectionsMap, labels)` and `optionalFieldAny(sectionsMap, labels)` and use them to read all issue fields.
- Allow the preferred slug to be optional by deriving `slugBase = preferredSlug || title` and keep sanitization (`sanitizeSlug`) and uniqueness via `ensureUniqueSlug` unchanged.
- Normalize scala filenames with `normalizeScalaFilename` which appends `.scl` when extension is omitted and enforces allowed extensions `.scl/.ascl/.scala`, throwing a helpful error message when invalid.
- Normalize KBM filenames with `normalizeKbmFilename` which appends `.kbm` when extension is omitted and enforces `.kbm` extension.
- Strengthen `validateFilename` to forbid path separators, leading dot files, control characters, and empty/whitespace-only names, and return the error: "Filename must be a plain filename (no folders), like `my-scale.scl`" when invalid.
- Keep `buildPackJson` output keys and placeholders exactly the same, including the `createdAt/updatedAt` placeholders.
- Add a smoke-test harness `tools/scaffold/scaffold-from-issue.test.mjs` using `node:test` that covers slug fallback, scala/KBM extension defaults, and invalid scala extension error formatting.

### Testing

- Added and ran `node --test tools/scaffold/scaffold-from-issue.test.mjs` which executed 4 tests and all passed.
- Tests cover: blank preferred slug falling back to title, scala filename `test` → `sources/test.scl`, line `foo.ascl | bar` → `sources/bar.kbm`, and invalid scala extension producing an error message mentioning `.scl, .ascl, or .scala`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b482ff76483278ea33d072a3f4193)