### PR TITLE
Harden pack submission parsing and form requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/pack_submission.yml
+++ b/.github/ISSUE_TEMPLATE/pack_submission.yml
@@ -89,18 +89,20 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
+  - type: dropdown
     id: multi_scale
     attributes:
       label: Multiple scales per pack?
       options:
-        - label: "Yes, this pack will include multiple scales (one .scl/.ascl/.scala per scale; optional .kbm per scale)"
-          required: false
+        - "Yes, this pack will include multiple scales (one .scl/.ascl/.scala per scale; optional .kbm per scale)"
+        - "No, this pack is a single scale"
+    validations:
+      required: true
 
   - type: textarea
     id: scale_files
     attributes:
-      label: Scale file list (filenames you intend to upload)
+      label: Scale files list (filenames you intend to upload)
       description: |
         One scale per line. Each line must include a filename ending in .scl, .ascl, or .scala.
         Optional KBM can be given after a separator: "|" (preferred) or ",".

--- a/tools/scaffold/scaffold-from-issue.mjs
+++ b/tools/scaffold/scaffold-from-issue.mjs
@@ -28,7 +28,12 @@ const preferredSlug = optionalFieldAny(sections, [
 ]);
 const author = requiredFieldAny(sections, ["Author display name", "Author name", "Author display name"]);
 const authorUrl = optionalFieldAny(sections, ["Author URL (optional)", "Author URL"]);
-const description = requiredFieldAny(sections, ["Short description", "Description (1–3 sentences)"]);
+const description = requiredFieldAny(sections, [
+  "Short description",
+  "Short description (1–3 sentences)",
+  "Description (1–3 sentences)",
+  "Description"
+]);
 const tagsRaw = requiredFieldAny(sections, ["Tags (comma-separated)", "Tags"]);
 const rootHzRaw = requiredFieldAny(sections, ["defaults.rootHz", "Root Hz default", "Root Hz"]);
 const primeLimitRaw = requiredFieldAny(sections, ["defaults.primeLimit", "Prime limit default", "Prime limit"]);
@@ -135,7 +140,11 @@ function requiredFieldAny(sectionsMap, labels) {
       return value.trim();
     }
   }
-  throw new Error(`Missing required field: ${labels[0]}`);
+  const foundHeadings = Array.from(sectionsMap.keys()).join(", ");
+  throw new Error(
+    `Missing required field. Tried: ${labels.join(" | ")}. ` +
+      `Found headings: ${foundHeadings || "none"}`
+  );
 }
 
 function optionalFieldAny(sectionsMap, labels) {

--- a/tools/scaffold/scaffold-from-issue.test.mjs
+++ b/tools/scaffold/scaffold-from-issue.test.mjs
@@ -13,6 +13,7 @@ function buildIssueBody(overrides = {}) {
     preferredSlug: "_No response_",
     author: "Test Author",
     authorUrl: "_No response_",
+    descriptionLabel: "Short description",
     description: "A short description.",
     tags: "tag-one, tag-two",
     rootHz: "440",
@@ -35,7 +36,7 @@ function buildIssueBody(overrides = {}) {
     "### Author URL (optional)",
     values.authorUrl,
     "",
-    "### Short description",
+    `### ${values.descriptionLabel}`,
     values.description,
     "",
     "### Tags (comma-separated)",
@@ -106,4 +107,14 @@ test("invalid scala extension throws with helpful message", () => {
   assert.notEqual(result.status, 0);
   const output = `${result.stdout}\n${result.stderr}`;
   assert.match(output, /\.scl, \.ascl, or \.scala/);
+});
+
+test("supports short description label with 1–3 sentences suffix", () => {
+  const { result, outputPath, tempDir } = runScaffold(
+    buildIssueBody({ descriptionLabel: "Short description (1–3 sentences)" })
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  const pack = readPackJson(tempDir, output.slug);
+  assert.equal(pack.description, "A short description.");
 });


### PR DESCRIPTION
### Motivation

- Fix a label mismatch that caused the scaffold parser to throw `Missing required field: Short description` even when the form was filled.
- Prevent users from creating blank/bypassed issues by forcing use of the issue form and making required fields explicit.

### Description

- Created `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` to disable blank issues and force the form.
- Updated `.github/ISSUE_TEMPLATE/pack_submission.yml` to make the multi-scale choice a required dropdown, add an explicit `Scale files list` label, and keep key fields required so the form cannot be submitted empty.
- Modified `tools/scaffold/scaffold-from-issue.mjs` to accept additional short-description headings by searching for `Short description`, `Short description (1–3 sentences)`, `Description (1–3 sentences)`, and `Description`, and improved `requiredFieldAny` errors to include the labels tried and the headings actually found.
- Extended `tools/scaffold/scaffold-from-issue.test.mjs` with a test that uses the `Short description (1–3 sentences)` heading to ensure the parser accepts the form output.

### Testing

- Ran the scaffold test suite with `node --test tools/scaffold/scaffold-from-issue.test.mjs`, which executed 5 tests and all passed.
- The new test `supports short description label with 1–3 sentences suffix` confirms the scaffold script no longer false-fails for the form-produced description heading.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b4b0e03cc8327b29aaa19d6b62815)