### PR TITLE
Fix actions/github-script inputs in scaffold-pack-pr workflow

### DIFF
--- a/.github/workflows/scaffold-pack-pr.yml
+++ b/.github/workflows/scaffold-pack-pr.yml
@@ -57,7 +57,8 @@ jobs:
         env:
           SLUG: ${{ steps.scaffold.outputs.slug }}
           PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
-          with:
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const issueNumber = context.issue.number;
             const { owner, repo } = context.repo;
@@ -99,4 +100,3 @@ jobs:
               issue_number: issueNumber,
               body
             });
-


### PR DESCRIPTION
### Motivation
- Fix a YAML nesting issue in the `actions/github-script` step that caused the action to receive no `script` input and fail with `Input required and not supplied: script`.

### Description
- In `/.github/workflows/scaffold-pack-pr.yml` move the `with:` block to be a sibling of `env:`, add `github-token: ${{ secrets.GITHUB_TOKEN }}`, and keep the existing script and `uploadUrl` unchanged.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b4e9dbf008327ad16a6adf519a2d4)